### PR TITLE
Updated for CSD 2023.1 directory structure NO_JIRA

### DIFF
--- a/scripts/multi_component_hydrogen_bond_propensity/ReadMe.md
+++ b/scripts/multi_component_hydrogen_bond_propensity/ReadMe.md
@@ -44,7 +44,9 @@ optional arguments:
                         the directory of the desired coformer library
 ```
 
-The default coformer library is the one supplied with your Mercury install in ```<CSD Install Location>\Mercury\molecular_libraries\ccdc_coformers```
+The default coformer library is the one supplied with your Mercury install
+- for 2023.1 or later, in ```<CSD Install Location>\ccdc-software\mercury\molecular_libraries\ccdc_coformers```
+- for 2022.3 or earlier, in ```<CSD Install Location>\Mercury\molecular_libraries\ccdc_coformers```
 
 Ensure the input structure and coformers have the correct bond typing and any charges before running the script
 

--- a/scripts/multi_component_hydrogen_bond_propensity/multi_component_hydrogen_bond_propensity_report.py
+++ b/scripts/multi_component_hydrogen_bond_propensity/multi_component_hydrogen_bond_propensity_report.py
@@ -363,19 +363,30 @@ def main(structure, work_directory, library, csdrefcode):
 
 if __name__ == '__main__':
     # Set up the necessary arguments to run the script
+    # For CSD 2023.1
     if sys.platform == 'win32':
         ccdc_coformers_dir = os.path.join(
-            os.path.dirname(io.csd_directory()),
-            'Mercury',
+            io.csd_directory(),
+            os.pardir, os.pardir,
+            'ccdc-software',
+            'mercury',
             'molecular_libraries',
-            'ccdc_coformers'
-        )
-    else:
-        ccdc_coformers_dir = os.path.join(
-            os.path.dirname(io.csd_directory()),
-            'molecular_libraries',
-            'ccdc_coformers'
-        )
+            'ccdc_coformers')
+    # CSD 2022.3 or earlier
+    if not os.path.exists(ccdc_coformers_dir):
+        if sys.platform == 'win32':
+            ccdc_coformers_dir = os.path.join(
+                os.path.dirname(io.csd_directory()),
+                'Mercury',
+                'molecular_libraries',
+                'ccdc_coformers'
+            )
+        else:
+            ccdc_coformers_dir = os.path.join(
+                os.path.dirname(io.csd_directory()),
+                'molecular_libraries',
+                'ccdc_coformers'
+            )
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__)


### PR DESCRIPTION
Minor change to locate the CCDC coformer library with the re-structured CSD installation directories in the CSD 2023.1 release