### PR TITLE
Added or statement to avoid negative networks in landscape NO_JIRA

### DIFF
--- a/scripts/hydrogen_bond_propensity/hydrogen_bond_propensity_report.py
+++ b/scripts/hydrogen_bond_propensity/hydrogen_bond_propensity_report.py
@@ -264,7 +264,7 @@ def hbp_landscape(groups, observed_groups, crystal, directory, work_directory, d
         highest_pairs = obs_pairs
 
     # Static legend
-    if highest_pairs <= 10:
+    if highest_pairs <= 10 or obs_pairs < 6:
         for i, colour in enumerate(hbp_colours):
             figure_i = plt.scatter([group.hbond_score for group in groups if len(group.hbonds) == i],
                                [abs(group.coordination_score) for group in groups if len(group.hbonds) == i],


### PR DESCRIPTION
The additional or statement catches extreme cases where there are calculated networks that have more that 10 Hbond pairs but the observed point has 5 or fewer observed interactions. Without this one can end up with a landscape showing some negative values for the intermolecular hydrogen bonds legend.
EHIYEZ01 with min donor and acceptor likelihoods set to 0 is a good example to see the issue