### PR TITLE
PR to verify disorders

### DIFF
--- a/scripts/multi_component_hydrogen_bond_propensity/ReadMe.md
+++ b/scripts/multi_component_hydrogen_bond_propensity/ReadMe.md
@@ -44,6 +44,8 @@ optional arguments:
                         the directory of the desired coformer library
   -f FAILURE_DIRECTORY, --failure_directory FAILURE_DIRECTORY
                         The location where the failures file should be generated
+  --force_run_disordered
+                        Forces running the script on disordered entries. (NOT RECOMMENDED)
 ```
 
 The default coformer library is the one supplied with your Mercury install

--- a/scripts/multi_component_hydrogen_bond_propensity/multi_component_hydrogen_bond_propensity_report.py
+++ b/scripts/multi_component_hydrogen_bond_propensity/multi_component_hydrogen_bond_propensity_report.py
@@ -314,7 +314,7 @@ def make_mc_report(identifier, results, directory, diagram_file, chart_file):
     launch_word_processor(output_file)
 
 
-def main(structure, work_directory, failure_directory, library, csdrefcode):
+def main(structure, work_directory, failure_directory, library, csdrefcode, force_run):
     # This loads up the CSD if a refcode is requested, otherwise loads the structural file supplied
     if csdrefcode:
         try:
@@ -322,6 +322,10 @@ def main(structure, work_directory, failure_directory, library, csdrefcode):
         except RuntimeError:
             print('Error! %s is not in the database!' % structure)
             quit()
+        if io.CrystalReader('CSD').entry(structure).has_disorder and not force_run:
+            raise RuntimeError("Disorder can cause undefined behaviour. It is not advisable to run this "
+                               "script on disordered entries.\n To force this script to run on disordered entries"
+                               " use the flag --force_run_disordered.")
     else:
         crystal = io.CrystalReader(structure)[0]
 
@@ -358,10 +362,11 @@ def main(structure, work_directory, failure_directory, library, csdrefcode):
                     tdata = get_mc_scores(propensities, crystal.identifier)
                     json.dump(tdata, file)
                 mc_dictionary[coformer_name] = get_mc_scores(propensities, crystal.identifier)
-            except RuntimeError:
+            except RuntimeError as error_message:
                 print("Propensity calculation failure for %s!" % coformer_name)
+                print(error_message)
                 mc_dictionary[coformer_name] = ["N/A", "N/A", "N/A", "N/A", "N/A", crystal.identifier]
-                failures.append(coformer_name)
+                failures.append(f"coformer_name: {error_message}")
 
     # Make sense of the outputs of all the calculations
     mc_hbp_screen = sorted(mc_dictionary.items(), key=lambda e: 0 if e[1][0] == 'N/A' else e[1][0], reverse=True)
@@ -411,6 +416,9 @@ if __name__ == '__main__':
     parser.add_argument('-f', '--failure_directory', type=str,
                         help='The location where the failures file should be generated')
 
+    parser.add_argument('--force_run_disordered', action="store_true",
+                        help='Forces running the script on disordered entries. (NOT RECOMMENDED)', default=False)
+
     args = parser.parse_args()
     refcode = False
     args.directory = os.path.abspath(args.directory)
@@ -424,4 +432,5 @@ if __name__ == '__main__':
     if not os.path.isdir(args.coformer_library):
         parser.error('%s - library not found.' % args.coformer_library)
 
-    main(args.input_structure, args.directory, args.failure_directory, args.coformer_library, refcode)
+    main(args.input_structure, args.directory, args.failure_directory, args.coformer_library, refcode,
+         args.force_run_disordered)


### PR DESCRIPTION
I stupidly forgot to verify if all mol2 files had 3d coordinates when creating a database of API and GRAS entries for my lab. I thought it would be a nice warning to have on the run. Furthermore, verifying if entries that use refcodes have disorder is trivial and I did it in the first commit. As this script uses a library of structural files, each file type handles disorder in a different way. So, it would be difficult to verify if the structure is disordered. 
Also, a while ago I thought it would be much better to provide the error message on the try-except statement. I totally forgot of committing it and including it in a PR, as I am using a fork of this script for my purposes.  I am sorry for that. I had the impression I had included the improvement in the way errors are handled in an older PR.  