### PR TITLE
Fixes problem that NoneTypes are TypeErrors

### DIFF
--- a/scripts/multi_component_hydrogen_bond_propensity/multi_component_hydrogen_bond_propensity_report.py
+++ b/scripts/multi_component_hydrogen_bond_propensity/multi_component_hydrogen_bond_propensity_report.py
@@ -362,7 +362,7 @@ def main(structure, work_directory, failure_directory, library, csdrefcode, forc
                     tdata = get_mc_scores(propensities, crystal.identifier)
                     json.dump(tdata, file)
                 mc_dictionary[coformer_name] = get_mc_scores(propensities, crystal.identifier)
-            except RuntimeError as error_message:
+            except Exception as error_message:
                 print("Propensity calculation failure for %s!" % coformer_name)
                 error_string = f"{coformer_name}: {error_message}"
                 warnings.warn(error_string)


### PR DESCRIPTION
The HBP on the API can return None if there is disorder in the coformers. None raises a TypeError in the MHBP. NoneTypes don't fall under RuntimeExceptions even though they are technically r This could be said to be a bad practice as some errors are due to problems that aren't individual to the coformer, but general system errors, like the R one. But, RuntimeException had the same problem, so I don't think in this case this is particularly bad.
I think that maybe in the future, the API could raise an DisorderException so users can treat exceptions less generally. 